### PR TITLE
make labels id long

### DIFF
--- a/github4s/src/main/scala/github4s/domain/Issue.scala
+++ b/github4s/src/main/scala/github4s/domain/Issue.scala
@@ -42,7 +42,7 @@ final case class Issue(
 )
 
 final case class Label(
-    id: Option[Int],
+    id: Option[Long],
     name: String,
     url: String,
     color: String,

--- a/github4s/src/test/scala/github4s/unit/DecodersSpec.scala
+++ b/github4s/src/test/scala/github4s/unit/DecodersSpec.scala
@@ -72,7 +72,7 @@ class DecodersSpec extends AnyFlatSpec with Matchers with FakeResponses {
   }
 
   case class Foo(a: Int)
-  it should "return a valid NonEmtpyList for a valid JSON" in {
+  it should "return a valid NonEmptyList for a valid JSON" in {
     decode[NonEmptyList[Foo]]("""{"a": 1}""") shouldBe Right(NonEmptyList(Foo(1), Nil))
   }
 


### PR DESCRIPTION
Migrate all the id fields in github objects from `int` to use `long`. Solves an issue when the ids go over the max int such as `2170205650` which we saw as an id for the labels

Previous
```scala
final case class SomeGitObject(
  id: Int
  ....
)
```

Now
```scala
final case class SomeGitObject(
  id: Long
  ....
)
```